### PR TITLE
Updated the http Swashbuckle mapping to reflect the real description

### DIFF
--- a/src/Shared/HttpResultsStatusCodeTypeHelpers.cs
+++ b/src/Shared/HttpResultsStatusCodeTypeHelpers.cs
@@ -32,13 +32,13 @@ internal static class HttpResultsStatusCodeTypeHelpers
         { "Workleap.Extensions.OpenAPI.TypedResult.InternalServerError`1", 500 },
     };
 
-    // Using the same descriptions from the Swashbuckle library: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+    // Using the same descriptions from the Swashbuckle library: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/fca056a330a8ddb5173eaa6ad912b77fd0cf0b39/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs#L1027
     public static Dictionary<int, string> StatusCodesToDescription { get; } = new()
     {
         { 200, "OK"},
         { 201, "Created" },
-        { 202, "OK" },
-        { 204, "Accepted" },
+        { 202, "Accepted" },
+        { 204, "No Content" },
         { 400, "Bad Request" },
         { 401, "Unauthorized" },
         { 403, "Forbidden" },


### PR DESCRIPTION
﻿<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
<!-- What was changed in this pull request? -->
This pull request includes updates to the `HttpResultsStatusCodeTypeHelpers` class in `src/Shared/HttpResultsStatusCodeTypeHelpers.cs`. The changes correct status code descriptions and update a reference link for clarity.

Updates to status code descriptions:

* Corrected the descriptions for HTTP status codes `202` and `204`. `202` is now labeled as "Accepted" instead of "OK," and `204` is now labeled as "No Content" instead of "Accepted."

Reference link update:

* Updated the reference link to the Swashbuckle library to point to a specific line in the file for better precision.
## Breaking changes
<!-- What breaking changes were added (if any) and how are they addressed? -->
None
