### PR TITLE
Updated the http Swashbuckle mapping to reflect the real description

### DIFF
--- a/src/Shared/HttpResultsStatusCodeTypeHelpers.cs
+++ b/src/Shared/HttpResultsStatusCodeTypeHelpers.cs
@@ -32,13 +32,13 @@ internal static class HttpResultsStatusCodeTypeHelpers
         { "Workleap.Extensions.OpenAPI.TypedResult.InternalServerError`1", 500 },
     };
 
-    // Using the same descriptions from the Swashbuckle library: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+    // Using the same descriptions from the Swashbuckle library: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/fca056a330a8ddb5173eaa6ad912b77fd0cf0b39/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs#L1027
     public static Dictionary<int, string> StatusCodesToDescription { get; } = new()
     {
         { 200, "OK"},
         { 201, "Created" },
-        { 202, "OK" },
-        { 204, "Accepted" },
+        { 202, "Accepted" },
+        { 204, "No Content" },
         { 400, "Bad Request" },
         { 401, "Unauthorized" },
         { 403, "Forbidden" },


### PR DESCRIPTION
﻿<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
<!-- What was changed in this pull request? -->
This pull request updates the `HttpResultsStatusCodeTypeHelpers` class to correct status code descriptions and improve the accuracy of referenced documentation.

Corrections to status code descriptions:

* [`src/Shared/HttpResultsStatusCodeTypeHelpers.cs`](diffhunk://#diff-bd1cf31908e22f3d28983b6cb3534e423b98ca7cc0e03fa801965a5e394e7f3dL35-R41): Updated the description for status code `202` from "OK" to "Accepted" and for status code `204` from "Accepted" to "No Content."

Improved documentation references:

* [`src/Shared/HttpResultsStatusCodeTypeHelpers.cs`](diffhunk://#diff-bd1cf31908e22f3d28983b6cb3534e423b98ca7cc0e03fa801965a5e394e7f3dL35-R41): Updated the Swashbuckle library link to point to a specific line in the referenced file for better traceability.
## Breaking changes
<!-- What breaking changes were added (if any) and how are they addressed? -->

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes