### PR TITLE
Add Cortex deployment tracker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,7 @@ jobs:
     uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: 'release'
+      cortexEntityIdOrTag: service-wl-extensions-openapi
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish.yml` file to include a new parameter for deployment configuration.

* Workflow configuration update:
  * Added the `cortexEntityIdOrTag` parameter with the value `service-wl-extensions-openapi` to the `jobs:` section of the workflow. This likely configures the deployment to associate with a specific Cortex entity or tag.